### PR TITLE
Add basic FastAPI server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,15 @@ WORKDIR /app
 
 # Copy application code and configs
 COPY agent /app/agent
+COPY orchestrator /app/orchestrator
 COPY configs /app/configs
 
 # Install runtime dependencies
-RUN pip install --no-cache-dir fastapi uvicorn
+RUN pip install --no-cache-dir fastapi uvicorn httpx
 
 # Default configuration path
 ENV CONFIG_PATH=/app/configs/echo.yaml
 
-EXPOSE 8000
+EXPOSE 8000 8001
 
 CMD ["python", "-m", "agent.main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Copy application code and configs
+COPY agent /app/agent
+COPY configs /app/configs
+
+# Install runtime dependencies
+RUN pip install --no-cache-dir fastapi uvicorn
+
+# Default configuration path
+ENV CONFIG_PATH=/app/configs/echo.yaml
+
+EXPOSE 8000
+
+CMD ["python", "-m", "agent.main"]

--- a/agent/main.py
+++ b/agent/main.py
@@ -1,0 +1,14 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.post("/")
+async def root() -> dict:
+    return {}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,10 @@ services:
       - ./configs:/app/configs:ro
     ports:
       - "8000:8000"
+  orchestrator:
+    build: .
+    depends_on:
+      - agent
+    command: ["python", "-m", "orchestrator.main"]
+    ports:
+      - "8001:8001"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.9'
+services:
+  agent:
+    build: .
+    environment:
+      CONFIG_PATH: /app/configs/echo.yaml
+    volumes:
+      - ./configs:/app/configs:ro
+    ports:
+      - "8000:8000"

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+import httpx
+
+app = FastAPI()
+
+
+@app.post("/")
+async def run_agent(payload: dict | None = None) -> dict:
+    async with httpx.AsyncClient() as client:
+        response = await client.post("http://agent:8000/", json=payload or {})
+        return response.json()
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8001)


### PR DESCRIPTION
## Summary
- create FastAPI app with POST endpoint returning empty JSON
- add uvicorn entrypoint for running server

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b416dc932c8324877806b628d1fb44