### PR TITLE
Split agent and orchestrator Dockerfiles

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,15 +1,7 @@
-FROM python:3.11-slim AS base
+FROM nanoagentlab-base:latest
 WORKDIR /app
-# Install runtime dependencies separately for better caching
-COPY agent/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-
-FROM base AS runtime
-# Copy application code and default configs
 COPY agent /app/agent
 COPY configs /app/configs
-
-# Default configuration path
 ENV CONFIG_PATH=/app/configs/agent.yaml
-
 EXPOSE 8000
+

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,13 +1,13 @@
-FROM python:3.11-slim
-
+FROM python:3.11-slim AS base
 WORKDIR /app
+# Install runtime dependencies separately for better caching
+COPY agent/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
+FROM base AS runtime
 # Copy application code and default configs
 COPY agent /app/agent
 COPY configs /app/configs
-
-# Install runtime dependencies
-RUN pip install --no-cache-dir fastapi uvicorn pyyaml
 
 # Default configuration path
 ENV CONFIG_PATH=/app/configs/agent.yaml

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Copy application code and default configs
+COPY agent /app/agent
+COPY configs /app/configs
+
+# Install runtime dependencies
+RUN pip install --no-cache-dir fastapi uvicorn pyyaml
+
+# Default configuration path
+ENV CONFIG_PATH=/app/configs/agent.yaml
+
+EXPOSE 8000

--- a/agent/main.py
+++ b/agent/main.py
@@ -21,5 +21,4 @@ if __name__ == "__main__":
     import uvicorn
 
     config = load_config()
-    syslog(co)
     uvicorn.run(app, host="0.0.0.0", port=config.get("port", 8000))

--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pyyaml

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY base/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+

--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+httpx
+pyyaml
+

--- a/configs/router.yaml
+++ b/configs/router.yaml
@@ -1,3 +1,3 @@
 port: 8101
-agent1_url: http://agent:8001/
-agent2_url: http://agent:8002/
+agent1_url: http://agent1:8001/
+agent2_url: http://agent2:8002/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,19 @@
 version: '3.9'
 services:
+  base:
+    build:
+      context: .
+      dockerfile: base/Dockerfile
+    image: nanoagentlab-base
+    profiles: ["build"]
+
   agent1:
     build:
       context: .
       dockerfile: agent/Dockerfile
+    image: nanoagentlab-agent
+    depends_on:
+      - base
     command: ["python", "-m", "agent.main"]
     environment:
       CONFIG_PATH: /app/configs/agent1/agent.yaml
@@ -11,10 +21,11 @@ services:
       - ./configs:/app/configs:ro
     ports:
       - "8001:8001"
+
   agent2:
-    build:
-      context: .
-      dockerfile: agent/Dockerfile
+    image: nanoagentlab-agent
+    depends_on:
+      - agent1
     command: ["python", "-m", "agent.main"]
     environment:
       CONFIG_PATH: /app/configs/agent2/agent.yaml
@@ -22,10 +33,12 @@ services:
       - ./configs:/app/configs:ro
     ports:
       - "8002:8002"
+
   orchestrator:
     build:
       context: .
       dockerfile: orchestrator/Dockerfile
+    image: nanoagentlab-orchestrator
     depends_on:
       - agent1
       - agent2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,31 @@
 version: '3.9'
 services:
   agent1:
-    build: .
+    build:
+      context: .
+      dockerfile: agent/Dockerfile
     command: ["python", "-m", "agent.main"]
     environment:
       CONFIG_PATH: /app/configs/agent1/agent.yaml
     volumes:
-      - ./configs:/app/configs/agent:ro
+      - ./configs:/app/configs:ro
     ports:
       - "8001:8001"
   agent2:
-    build: .
-    command: [ "python", "-m", "agent.main" ]
+    build:
+      context: .
+      dockerfile: agent/Dockerfile
+    command: ["python", "-m", "agent.main"]
     environment:
       CONFIG_PATH: /app/configs/agent2/agent.yaml
     volumes:
-      - ./configs:/app/configs/agent:ro
+      - ./configs:/app/configs:ro
     ports:
       - "8002:8002"
   orchestrator:
-    build: .
+    build:
+      context: .
+      dockerfile: orchestrator/Dockerfile
     depends_on:
       - agent1
       - agent2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   base:
     build:
@@ -12,8 +11,6 @@ services:
       context: .
       dockerfile: agent/Dockerfile
     image: nanoagentlab-agent
-    depends_on:
-      - base
     command: ["python", "-m", "agent.main"]
     environment:
       CONFIG_PATH: /app/configs/agent1/agent.yaml

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -2,8 +2,7 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# Copy application code and configs
-COPY agent /app/agent
+# Copy application code and default configs
 COPY orchestrator /app/orchestrator
 COPY configs /app/configs
 
@@ -11,6 +10,6 @@ COPY configs /app/configs
 RUN pip install --no-cache-dir fastapi uvicorn httpx pyyaml
 
 # Default configuration path
-ENV CONFIG_PATH=/app/configs/agent.yaml
+ENV CONFIG_PATH=/app/configs/router.yaml
 
-EXPOSE 8101 8001 8002
+EXPOSE 8101

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -1,15 +1,7 @@
-FROM python:3.11-slim AS base
+FROM nanoagentlab-base:latest
 WORKDIR /app
-# Install runtime dependencies separately for better caching
-COPY orchestrator/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-
-FROM base AS runtime
-# Copy application code and default configs
 COPY orchestrator /app/orchestrator
 COPY configs /app/configs
-
-# Default configuration path
 ENV CONFIG_PATH=/app/configs/router.yaml
-
 EXPOSE 8101
+

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -1,13 +1,13 @@
-FROM python:3.11-slim
-
+FROM python:3.11-slim AS base
 WORKDIR /app
+# Install runtime dependencies separately for better caching
+COPY orchestrator/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
+FROM base AS runtime
 # Copy application code and default configs
 COPY orchestrator /app/orchestrator
 COPY configs /app/configs
-
-# Install runtime dependencies
-RUN pip install --no-cache-dir fastapi uvicorn httpx pyyaml
 
 # Default configuration path
 ENV CONFIG_PATH=/app/configs/router.yaml

--- a/orchestrator/requirements.txt
+++ b/orchestrator/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+httpx
+pyyaml


### PR DESCRIPTION
## Summary
- separate Dockerfiles for agents and orchestrator with needed deps
- fix router config and docker-compose to use the new images and correct hostnames
- remove stray code in agent main for reliable startup

## Testing
- `python -m py_compile agent/main.py orchestrator/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b705a5a6a08324ae093647bf110095